### PR TITLE
Bug fix for error when parsing Azure plan

### DIFF
--- a/.github/workflows/keyfactor-starter-workflow.yml
+++ b/.github/workflows/keyfactor-starter-workflow.yml
@@ -5,30 +5,17 @@ jobs:
   call-create-github-release-workflow:
     uses: Keyfactor/actions/.github/workflows/github-release.yml@main
 
-  get-manifest-properties:
-    runs-on: windows-latest
-    outputs:
-      update_catalog: ${{ steps.read-json.outputs.update_catalog }}
-      integration_type:  ${{ steps.read-json.outputs.integration_type }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Store json
-        id: read-json
-        shell: pwsh
-        run: |
-          $json = Get-Content integration-manifest.json | ConvertFrom-Json
-          $myvar = $json.update_catalog
-          echo "update_catalog=$myvar" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-          $myvar = $json.integration_type
-          echo "integration_type=$myvar" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+  call-assign-from-json-workflow:
+    uses: Keyfactor/actions/.github/workflows/assign-env-from-json.yml@main
 
   call-dotnet-build-and-release-workflow:
-    needs: [call-create-github-release-workflow]
+    needs: [call-create-github-release-workflow, call-assign-from-json-workflow]
     uses: Keyfactor/actions/.github/workflows/dotnet-build-and-release.yml@main
     with:
       release_version: ${{ needs.call-create-github-release-workflow.outputs.release_version }}
       release_url: ${{ needs.call-create-github-release-workflow.outputs.release_url }}
-      release_dir: AzureKeyVault\bin\Release
+      release_dir: ${{ needs.call-assign-from-json-workflow.outputs.release_dir }}
+
     secrets: 
       token: ${{ secrets.PRIVATE_PACKAGE_ACCESS }}
 
@@ -37,17 +24,3 @@ jobs:
     uses: Keyfactor/actions/.github/workflows/generate-readme.yml@main
     secrets:
       token: ${{ secrets.APPROVE_README_PUSH }}
-
-  call-update-catalog-workflow:
-    needs: get-manifest-properties
-    if: needs.get-manifest-properties.outputs.update_catalog == 'True' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    uses: Keyfactor/actions/.github/workflows/update-catalog.yml@main
-    secrets: 
-      token: ${{ secrets.SDK_SYNC_PAT }}
-
-  call-update-store-types-workflow:
-    needs: get-manifest-properties
-    if: needs.get-manifest-properties.outputs.integration_type == 'orchestrator' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    uses: Keyfactor/actions/.github/workflows/update-store-types.yml@main
-    secrets: 
-      token: ${{ secrets.UPDATE_STORE_TYPES }}

--- a/AzureKeyVault.sln
+++ b/AzureKeyVault.sln
@@ -7,6 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureKeyVault", "AzureKeyVa
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AB1BF579-FBD3-4F59-BBF2-7B973B9AD1DB}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		integration-manifest.json = integration-manifest.json
 		readme_source.md = readme_source.md
 	EndProjectSection

--- a/AzureKeyVault/Jobs/AzureKeyVaultJob.cs
+++ b/AzureKeyVault/Jobs/AzureKeyVaultJob.cs
@@ -42,7 +42,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                 VaultProperties.TenantId = VaultProperties.TenantId != null ? VaultProperties.TenantId : properties.dirs;
                 VaultProperties.ResourceGroupName = properties.ResourceGroupName;
                 VaultProperties.VaultName = properties.VaultName;
-                VaultProperties.PremiumSKU = "premium".Equals(properties.SkuType, System.StringComparison.OrdinalIgnoreCase);
+                VaultProperties.PremiumSKU = properties.SkuType == "premium";
                 VaultProperties.VaultRegion = properties.VaultRegion ?? "eastus";
                 VaultProperties.VaultRegion = VaultProperties.VaultRegion.ToLower();
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,3 @@
   - Removed ObjectId parameter from StoreType definition
   - Added SkuType and VaultRegion parameters to support vault creation from the platform.
 
-- 1.05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-﻿
+﻿- 2.0.1
+  - Fixed bug when trying to parse Vault plan (premium/standard)
 
 - 2.0
   - Added support for Azure Managed Identity authentication

--- a/README.md
+++ b/README.md
@@ -14,14 +14,11 @@ The Universal Orchestrator is part of the Keyfactor software distribution and is
 The Universal Orchestrator is the successor to the Windows Orchestrator. This Orchestrator Extension plugin only works with the Universal Orchestrator and does not work with the Windows Orchestrator.
 
 
-
-
 ## Support for Azure Key Vault Orchestrator
 
 Azure Key Vault Orchestrator is supported by Keyfactor for Keyfactor customers. If you have a support issue, please open a support ticket with your Keyfactor representative.
 
 ###### To report a problem or suggest a new feature, use the **[Issues](../../issues)** tab. If you want to contribute actual bug fixes or proposed enhancements, use the **[Pull requests](../../pulls)** tab.
-
 
 
 ---

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -6,6 +6,7 @@
   "update_catalog": true,
   "link_github": true,
   "support_level": "kf-supported",
+  "release_dir": "AzureKeyVault/bin/Release",
   "description": "This integration allows the orchestrator to act as a client with access to an instance of the Azure Key Vault; allowing you to manage your certificates stored in the Azure Keyvault via Keyfactor.",
   "about": {
     "orchestrator": {


### PR DESCRIPTION
- Addresses the case where users would see the following error when trying to parse the Azure KeyVault plan name.

"Member 'object.Equals(object, object)' cannot be accessed with an instance reference; qualify it with a type name instead"