### PR TITLE
Bug fix for error when adding new cert with overwrite unchecked (#46)

### DIFF
--- a/AzureKeyVault/AzureKeyVault.csproj
+++ b/AzureKeyVault/AzureKeyVault.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
@@ -23,7 +23,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" Version="1.11.3" />
+		<PackageReference Include="Azure.Core" Version="1.40.0" />
+		<PackageReference Include="Azure.Identity" Version="1.12.0" />
 		<PackageReference Include="Azure.ResourceManager" Version="1.12.0" />
 		<PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.2.3" />
 		<PackageReference Include="Azure.ResourceManager.Resources" Version="1.7.3" />
@@ -39,6 +40,8 @@
 		<PackageReference Include="Keyfactor.Orchestrators.IOrchestratorJobExtensions" Version="0.7.0" />
 		<PackageReference Include="Keyfactor.Platform.IPAMProvider" Version="1.0.0" />
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/AzureKeyVault/Jobs/Management.cs
+++ b/AzureKeyVault/Jobs/Management.cs
@@ -106,8 +106,8 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                     if (!overwrite)
                     {
                         logger.LogTrace($"checking for an existing cert with the alias {alias}");
-                        var existing = AzClient.GetCertificate(alias);
-                        if (existing != null && !overwrite)
+                        var existing = AzClient.GetCertificate(alias).Result;
+                        if (existing != null)
                         {
                             var message = $"A certificate named {alias} already exists and the overwrite checkbox was unchecked.  No action was taken.";
                             logger.LogWarning(message);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-- - 3.1.4
+- 3.1.5
+  - Bug fix for error when adding new cert and overwrite is unchecked
+	
+- 3.1.4
   - Update nuget dependencies (Azure Identity Packages)
 
-- - 3.1.3
+- 3.1.3
   - Discovery now continues the search if an error is encountered during the process. 
   - Fixed issue with overwrite box check being ignored when replacing cert in Keyvault
   -	Now getting properties of certs as pageable during inventory to fix a timeout issue when querying for thousands of certs.


### PR DESCRIPTION
  - Preventing CertStore parameters from getting used if present but empty. 	
  - Improved trace logging