### PR TITLE
Added support for certificate tags

### DIFF
--- a/AzureKeyVault/AkvProperties.cs
+++ b/AzureKeyVault/AkvProperties.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 using System.Collections.Generic;
 

--- a/AzureKeyVault/AzureClient.cs
+++ b/AzureKeyVault/AzureClient.cs
@@ -331,7 +331,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                 }
             }
 
-            if (failedCount == fullInventoryList.Count())
+            if (failedCount == fullInventoryList.Count() && failedCount > 0)
             {
                 throw new Exception("Unable to retreive details for certificates.", innerException);
             }

--- a/AzureKeyVault/AzureKeyVault.csproj
+++ b/AzureKeyVault/AzureKeyVault.csproj
@@ -18,23 +18,24 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Core" Version="1.44.1" />
-		<PackageReference Include="Azure.Identity" Version="1.13.1" />
+		<PackageReference Include="Azure.Core" Version="1.45.0" />
+		<PackageReference Include="Azure.Identity" Version="1.13.2" />
 		<PackageReference Include="Azure.ResourceManager" Version="1.13.0" />
 		<PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.3.0" />
 		<PackageReference Include="Azure.ResourceManager.Resources" Version="1.9.0" />
 		<PackageReference Include="Azure.Security.KeyVault.Administration" Version="4.5.0" />
 		<PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
-		<PackageReference Include="Keyfactor.Logging" Version="1.1.1" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
+		<PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
+		<PackageReference Include="Keyfactor.Logging" Version="1.1.2" />
 		<PackageReference Include="Keyfactor.Orchestrators.Common" Version="3.2.0" />
 		<PackageReference Include="Keyfactor.Orchestrators.IOrchestratorJobExtensions" Version="0.7.0" />
 		<PackageReference Include="Keyfactor.Platform.IPAMProvider" Version="1.0.0" />
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.66.1" />
-		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.1" />
-		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.68.0" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.68.0" />
+		<PackageReference Include="System.Drawing.Common" Version="9.0.2" />
 		<PackageReference Include="System.Linq" Version="4.3.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>

--- a/AzureKeyVault/Constants.cs
+++ b/AzureKeyVault/Constants.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
 {

--- a/AzureKeyVault/Helpers.cs
+++ b/AzureKeyVault/Helpers.cs
@@ -1,0 +1,89 @@
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
+using System;
+using System.IO;
+using System.Text.Json.Nodes;
+
+namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
+{
+    public static class Helpers
+    {
+        public static bool IsValidJson(this string jsonString)
+        {
+            try
+            {
+                var unescapedJSON = System.Text.RegularExpressions.Regex.Unescape(jsonString);
+                var tmpObj = JsonValue.Parse(unescapedJSON);
+            }
+            catch (FormatException fex)
+            {
+                //Invalid json format
+                return false;
+            }
+            catch (Exception ex) //some other exception
+            {
+                return false;
+            }
+            return true;
+        }
+        public static byte[] ConvertPfxToPasswordlessPkcs12(string base64Pfx, string pfxPassword)
+        {
+            // Decode the Base64-encoded PFX data
+            byte[] pfxBytes = Convert.FromBase64String(base64Pfx);
+            using (var inputStream = new MemoryStream(pfxBytes))
+            {
+                var builder = new Pkcs12StoreBuilder();
+                builder.SetUseDerEncoding(true);
+                var store = builder.Build();
+                store.Load(inputStream, pfxPassword.ToCharArray());
+
+                string alias = null;
+                foreach (string a in store.Aliases)
+                {
+                    if (store.IsKeyEntry(a))
+                    {
+                        alias = a;
+                        break;
+                    }
+                }
+
+                using (var outputStream = new MemoryStream())
+                {
+                    var newStore = builder.Build();
+
+                    if (alias != null)
+                    {
+                        // Extract private key and certificate chain if available
+                        var keyEntry = store.GetKey(alias);
+                        var chain = store.GetCertificateChain(alias);
+                        newStore.SetKeyEntry("converted-key", keyEntry, chain);
+                    }
+                    else
+                    {
+                        // If no private key, include just the certificate chain
+                        foreach (string certAlias in store.Aliases)
+                        {
+                            if (store.IsCertificateEntry(certAlias))
+                            {
+                                var cert = store.GetCertificate(certAlias);
+                                newStore.SetCertificateEntry(certAlias, cert);
+                            }
+                        }
+                    }
+
+                    // Save the new PKCS#12 store without a password
+                    newStore.Save(outputStream, null, new SecureRandom());
+                    return outputStream.ToArray();
+                }
+            }
+        }
+    }
+}

--- a/AzureKeyVault/JobAttribute.cs
+++ b/AzureKeyVault/JobAttribute.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 using System;
 

--- a/AzureKeyVault/Jobs/AzureKeyVaultJob.cs
+++ b/AzureKeyVault/Jobs/AzureKeyVaultJob.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/AzureKeyVault/Jobs/Discovery.cs
+++ b/AzureKeyVault/Jobs/Discovery.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/AzureKeyVault/Jobs/Inventory.cs
+++ b/AzureKeyVault/Jobs/Inventory.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/AzureKeyVault/PamUtilities.cs
+++ b/AzureKeyVault/PamUtilities.cs
@@ -1,9 +1,10 @@
-﻿// Copyright 2023 Keyfactor
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-// and limitations under the License.
+﻿
+//  Copyright 2025 Keyfactor
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 using Keyfactor.Orchestrators.Extensions.Interfaces;
 using Microsoft.Extensions.Logging;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 3.1.7
+  - Added support for Azure KeyVault Certificate Metadata via Entry Parameters
+  - Converted to BouncyCastle crypto libraries
+  -	Convert to .net6/8 dual build
+  - Update README to use doctool
+	
 - 3.1.6
   - Preventing CertStore parameters from getting used if present but empty. 	
   - Improved trace logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 - 3.1.7
   - Added support for Azure KeyVault Certificate Metadata via Entry Parameters
+  - Fixed issue where an error would be returned during Inventory if 0 certificates were found
   - Converted to BouncyCastle crypto libraries
   -	Convert to .net6/8 dual build
-  - Update README to use doctool
+  - Update README to use doctool  
 	
 - 3.1.6
   - Preventing CertStore parameters from getting used if present but empty. 	

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -36,7 +36,14 @@
           "BlueprintAllowed": false,
           "Capability": "AKV",
           "CustomAliasAllowed": "Optional",
-          "EntryParameters": [],
+          "EntryParameters": [
+            {
+              "Name": "CertificateTags",
+              "DisplayName": "Certificate Tags",
+              "Type": "string",
+              "DefaultValue": ""
+            }
+          ],
           "JobProperties": [],
           "LocalStore": false,
           "Name": "Azure Keyvault",

--- a/readme_source.md
+++ b/readme_source.md
@@ -456,6 +456,22 @@ Now we can navigate to the Keyfactor platform and create the store type for Azur
      you can limit the options to those that should be applicable to your organization. Refer to the [Azure Documentation](https://learn.microsoft.com/en-us/dotnet/api/azure.core.azurelocation?view=azure-dotnethttps://learn.microsoft.com/en-us/dotnet/api/azure.core.azurelocation?view=azure-dotnet) for a list of valid region names.
      If no value is selected, "eastus" is used by default.
 
+
+#### Certificate Tags (v3.1.7+)
+If you would like to utilize Tags for associating arbitrary data with a Certificate in Azure KeyVault, you can utilize an entry parameter named "CertificateTags".
+
+Name: **"CertificateTags"** 
+
+Display Name: **"Certificate Tags"**
+
+Type: **String**
+
+When supplied, this field should contain valid JSON representing a key-value dictionary.  
+
+example: 
+```json
+{{"myTag":"myTagValue"}, {"anotherTag":"anotherTagValue"}}
+```
 ### Install the Extension on the Orchestrator
 
 The process for installing an extension for the universal orchestrator differs from the process of installing an extension for the Windows orchestrator.  Follow the below steps to register the Azure Keyvault integration with your instance of the universal orchestrator.


### PR DESCRIPTION
  - Added support for Azure KeyVault Certificate Metadata via Entry Parameters
  - Fixed issue where an error would be returned during Inventory if 0 certificates were found
  - Converted to BouncyCastle crypto libraries
  -	Convert to .net6/8 dual build
  - Update README to use doctool  