### PR TITLE
Added entry parameter to indicate the private key should not be exportable from KeyVault

### DIFF
--- a/AzureKeyVault/AzureClient.cs
+++ b/AzureKeyVault/AzureClient.cs
@@ -199,7 +199,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
             }
         }
 
-        public virtual async Task<KeyVaultCertificateWithPolicy> ImportCertificateAsync(string certName, string contents, string pfxPassword, Dictionary<string,string> tags, bool nonExportable)
+        public virtual async Task<KeyVaultCertificateWithPolicy> ImportCertificateAsync(string certName, string contents, string pfxPassword, Dictionary<string, string> tags, bool nonExportable)
         {
             try
             {
@@ -221,7 +221,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                 logger.LogTrace($"calling ImportCertificateAsync on the KeyVault certificate client to import certificate {certName}");
 
                 var options = new ImportCertificateOptions(certName, p12bytes);
-                options.Policy.Exportable = nonExportable;
+                options.Policy = new CertificatePolicy { Exportable = !nonExportable, ContentType = CertificateContentType.Pkcs12 };
 
                 if (tags.Any())
                 {
@@ -389,7 +389,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                 var warning = $"Exception thrown performing discovery on tenantId {searchTenantId} and subscription ID {searchSubscription}.  Exception message: {ex.Message}";
 
                 logger.LogWarning(warning);
-                warnings.Add(warning);                
+                warnings.Add(warning);
             }
 
             return (vaultNames, warnings);

--- a/AzureKeyVault/AzureClient.cs
+++ b/AzureKeyVault/AzureClient.cs
@@ -199,7 +199,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
             }
         }
 
-        public virtual async Task<KeyVaultCertificateWithPolicy> ImportCertificateAsync(string certName, string contents, string pfxPassword, Dictionary<string,string> tags)
+        public virtual async Task<KeyVaultCertificateWithPolicy> ImportCertificateAsync(string certName, string contents, string pfxPassword, Dictionary<string,string> tags, bool nonExportable)
         {
             try
             {
@@ -221,6 +221,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                 logger.LogTrace($"calling ImportCertificateAsync on the KeyVault certificate client to import certificate {certName}");
 
                 var options = new ImportCertificateOptions(certName, p12bytes);
+                options.Policy.Exportable = nonExportable;
 
                 if (tags.Any())
                 {

--- a/AzureKeyVault/Constants.cs
+++ b/AzureKeyVault/Constants.cs
@@ -16,6 +16,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
     static class EntryParameters {
         public const string TAGS = "CertificateTags";
         public const string PRESERVE_TAGS = "PreserveExistingTags";
+        public const string NON_EXPORTABLE = "NonExportable";
     }
 
     static class JobTypes

--- a/AzureKeyVault/Jobs/Management.cs
+++ b/AzureKeyVault/Jobs/Management.cs
@@ -46,11 +46,13 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
 
             string tagsJSON;
             bool preserveTags;
+            bool nonExportable;
 
             logger.LogTrace("parsing entry parameters.. ");
 
             tagsJSON = config.JobProperties[EntryParameters.TAGS] as string ?? string.Empty;
             preserveTags = config.JobProperties[EntryParameters.PRESERVE_TAGS] as bool? ?? false;
+            nonExportable = config.JobProperties[EntryParameters.NON_EXPORTABLE] as bool? ?? false;
 
             switch (config.OperationType)
             {
@@ -61,7 +63,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                 case CertStoreOperationType.Add:
                     logger.LogDebug($"Begin Management > Add...");
 
-                    complete = PerformAddition(config.JobCertificate.Alias, config.JobCertificate.PrivateKeyPassword, config.JobCertificate.Contents, tagsJSON, config.JobHistoryId, config.Overwrite, preserveTags);
+                    complete = PerformAddition(config.JobCertificate.Alias, config.JobCertificate.PrivateKeyPassword, config.JobCertificate.Contents, tagsJSON, config.JobHistoryId, config.Overwrite, preserveTags, nonExportable);
                     break;
                 case CertStoreOperationType.Remove:
                     logger.LogDebug($"Begin Management > Remove...");
@@ -103,7 +105,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
         #endregion
 
         #region Add
-        protected virtual JobResult PerformAddition(string alias, string pfxPassword, string entryContents, string tagsJSON, long jobHistoryId, bool overwrite, bool preserveTags)
+        protected virtual JobResult PerformAddition(string alias, string pfxPassword, string entryContents, string tagsJSON, long jobHistoryId, bool overwrite, bool preserveTags, bool nonExportable)
         {
             var complete = new JobResult() { Result = OrchestratorJobStatusJobResult.Failure, JobHistoryId = jobHistoryId };
 
@@ -173,7 +175,7 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                         }
                     }
 
-                    var cert = AzClient.ImportCertificateAsync(alias, entryContents, pfxPassword, tagDict).Result;
+                    var cert = AzClient.ImportCertificateAsync(alias, entryContents, pfxPassword, tagDict, nonExportable).Result;
 
                     // Ensure the return object has a AKV version tag, and Thumbprint
                     if (!string.IsNullOrEmpty(cert.Properties.Version) &&

--- a/AzureKeyVault/Jobs/Management.cs
+++ b/AzureKeyVault/Jobs/Management.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging;
 using Keyfactor.Orchestrators.Extensions.Interfaces;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using System.Security.AccessControl;
 
 namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
 {
@@ -140,16 +139,16 @@ namespace Keyfactor.Extensions.Orchestrator.AzureKeyVault
                     if (existing != null)
                     {
                         logger.LogTrace($"there is an existing cert..");
-                    }
 
-                    existingTags = existing?.Properties.Tags as Dictionary<string, string> ?? new Dictionary<string, string>();
+                        existingTags = existing?.Properties.Tags as Dictionary<string, string> ?? new Dictionary<string, string>();
 
-                    logger.LogTrace("existing cert tags: ");
-                    if (!existingTags.Any()) logger.LogTrace("(none)");
+                        logger.LogTrace("existing cert tags: ");
+                        if (!existingTags.Any()) logger.LogTrace("(none)");
 
-                    foreach (var tag in existingTags)
-                    {
-                        logger.LogTrace(tag.Key + " : " + tag.Value);
+                        foreach (var tag in existingTags)
+                        {
+                            logger.LogTrace(tag.Key + " : " + tag.Value);
+                        }
                     }
 
                     // if overwrite is unchecked, check for an existing cert first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+- 3.2.0
+  - added an optional entry parameter to indicate whether the private key of the cert should be not exportable when stored in KeyVault
+  - now specifying the pkcs12 format when wirting certs to Azure KeyVault.  This should prevent the error when a PEM cert was added outside of Command and then we attempt to update without specifying the format (Azure assumes PEM and throws an error if not).
+
 - 3.1.9
   - Added optional entry parameter to indicate that existing tags should be preserved if certificate is replaced
-  - bug fix for government cloud host name resolution
 
 - 3.1.8
   - Fixed bug where enrollment would fail if the CertificateTags field was not defined as an entry parameter	
@@ -11,7 +14,6 @@
   - Added support for Azure KeyVault Certificate Metadata via Entry Parameters
   - Fixed issue where an error would be returned during Inventory if 0 certificates were found
   - Converted to BouncyCastle crypto libraries
-
 	
 - 3.1.6
   - Preventing CertStore parameters from getting used if present but empty. 	

--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ the Keyfactor Command Portal
    | ---- | ------------ | ---- | ------------- | ----------------------- | ---------------- | ----------------- | ------------------- | ----------- |
    | CertificateTags | Certificate Tags | If desired, tags can be applied to the KeyVault entries.  Provide them as a JSON string of key-value pairs ie: '{'tag-name': 'tag-content', 'other-tag-name': 'other-tag-content'}' | string |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | PreserveExistingTags | Preserve Existing Tags | If true, this will perform a union of any tags provided with enrollment with the tags on the existing cert with the same alias and apply the result to the new certificate. | Bool | False | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
-   | NonExportable | Non Exportable | If true, this will mark the certificate as 'non-exportable' when importing into Azure KeyVault | Bool | False | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
+   | NonExportable | Non Exportable Private Key | If true, this will mark the certificate as having a non-exportable private key when importing into Azure KeyVault | Bool | False | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
 
    The Entry Parameters tab should look like this:
 
@@ -721,8 +721,8 @@ the Keyfactor Command Portal
    ![AKV Entry Parameter - PreserveExistingTags](docsource/images/AKV-entry-parameters-store-type-dialog-PreserveExistingTags.png)
 
 
-   ##### Non Exportable
-   If true, this will mark the certificate as 'non-exportable' when importing into Azure KeyVault
+   ##### Non Exportable Private Key
+   If true, this will mark the certificate as having a non-exportable private key when importing into Azure KeyVault
 
    ![AKV Entry Parameter - NonExportable](docsource/images/AKV-entry-parameters-store-type-dialog-NonExportable.png)
 

--- a/README.md
+++ b/README.md
@@ -658,16 +658,75 @@ the Keyfactor Command Portal
 
    ![AKV Custom Fields Tab](docsource/images/AKV-custom-fields-store-type-dialog.png)
 
+
+   ###### Tenant Id
+   The ID of the primary Azure Tenant where the KeyVaults are hosted
+
+   ![AKV Custom Field - TenantId](docsource/images/AKV-custom-field-TenantId-dialog.png)
+
+
+
+   ###### SKU Type
+   The SKU type for newly created KeyVaults (only needed if needing to create new KeyVaults in your Azure subscription via Command)
+
+   ![AKV Custom Field - SkuType](docsource/images/AKV-custom-field-SkuType-dialog.png)
+
+
+
+   ###### Vault Region
+   The Azure Region to put newly created KeyVaults (only needed if needing to create new KeyVaults in your Azure subscription via Command)
+
+   ![AKV Custom Field - VaultRegion](docsource/images/AKV-custom-field-VaultRegion-dialog.png)
+
+
+
+   ###### Azure Cloud
+   The Azure Cloud where the KeyVaults are located (only necessary if not using the standard Azure Public cloud)
+
+   ![AKV Custom Field - AzureCloud](docsource/images/AKV-custom-field-AzureCloud-dialog.png)
+
+
+
+   ###### Private KeyVault Endpoint
+   The private endpoint of your vault instance (if a private endpoint is configured in Azure)
+
+   ![AKV Custom Field - PrivateEndpoint](docsource/images/AKV-custom-field-PrivateEndpoint-dialog.png)
+
+
+
+
+
    ##### Entry Parameters Tab
 
    | Name | Display Name | Description | Type | Default Value | Entry has a private key | Adding an entry | Removing an entry | Reenrolling an entry |
    | ---- | ------------ | ---- | ------------- | ----------------------- | ---------------- | ----------------- | ------------------- | ----------- |
    | CertificateTags | Certificate Tags | If desired, tags can be applied to the KeyVault entries.  Provide them as a JSON string of key-value pairs ie: '{'tag-name': 'tag-content', 'other-tag-name': 'other-tag-content'}' | string |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | PreserveExistingTags | Preserve Existing Tags | If true, this will perform a union of any tags provided with enrollment with the tags on the existing cert with the same alias and apply the result to the new certificate. | Bool | False | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
+   | NonExportable | Non Exportable | If true, this will mark the certificate as 'non-exportable' when importing into Azure KeyVault | Bool | False | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
 
    The Entry Parameters tab should look like this:
 
    ![AKV Entry Parameters Tab](docsource/images/AKV-entry-parameters-store-type-dialog.png)
+
+
+   ##### Certificate Tags
+   If desired, tags can be applied to the KeyVault entries.  Provide them as a JSON string of key-value pairs ie: '{'tag-name': 'tag-content', 'other-tag-name': 'other-tag-content'}'
+
+   ![AKV Entry Parameter - CertificateTags](docsource/images/AKV-entry-parameters-store-type-dialog-CertificateTags.png)
+
+
+   ##### Preserve Existing Tags
+   If true, this will perform a union of any tags provided with enrollment with the tags on the existing cert with the same alias and apply the result to the new certificate.
+
+   ![AKV Entry Parameter - PreserveExistingTags](docsource/images/AKV-entry-parameters-store-type-dialog-PreserveExistingTags.png)
+
+
+   ##### Non Exportable
+   If true, this will mark the certificate as 'non-exportable' when importing into Azure KeyVault
+
+   ![AKV Entry Parameter - NonExportable](docsource/images/AKV-entry-parameters-store-type-dialog-NonExportable.png)
+
+
 
    </details>
 
@@ -675,15 +734,14 @@ the Keyfactor Command Portal
 
 1. **Download the latest Azure Key Vault Universal Orchestrator extension from GitHub.**
 
-    Navigate to the [Azure Key Vault Universal Orchestrator extension GitHub version page](https://github.com/Keyfactor/azurekeyvault-orchestrator/releases/latest). Refer to the compatibility matrix below to determine whether the `net6.0` or `net8.0` asset should be downloaded. Then, click the corresponding asset to download the zip archive.
+    Navigate to the [Azure Key Vault Universal Orchestrator extension GitHub version page](https://github.com/Keyfactor/azurekeyvault-orchestrator/releases/latest). Refer to the compatibility matrix below to determine the asset should be downloaded. Then, click the corresponding asset to download the zip archive.
 
    | Universal Orchestrator Version | Latest .NET version installed on the Universal Orchestrator server | `rollForward` condition in `Orchestrator.runtimeconfig.json` | `azurekeyvault-orchestrator` .NET version to download |
    | --------- | ----------- | ----------- | ----------- |
    | Older than `11.0.0` | | | `net6.0` |
    | Between `11.0.0` and `11.5.1` (inclusive) | `net6.0` | | `net6.0` |
-   | Between `11.0.0` and `11.5.1` (inclusive) | `net8.0` | `Disable` | `net6.0` |
-   | Between `11.0.0` and `11.5.1` (inclusive) | `net8.0` | `LatestMajor` | `net8.0` |
-   | `11.6` _and_ newer | `net8.0` | | `net8.0` |
+   | Between `11.0.0` and `11.5.1` (inclusive) | `net8.0` | `Disable` | `net6.0` || Between `11.0.0` and `11.5.1` (inclusive) | `net8.0` | `LatestMajor` | `net8.0` |
+   | `11.6` _and_ newer | `net8.0` | | `net8.0` | 
 
     Unzip the archive containing extension assemblies to a known location.
 

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -49,8 +49,8 @@
             },
             {
               "Name": "NonExportable",
-              "DisplayName": "Non Exportable",
-              "Description": "If true, this will mark the certificate as 'non-exportable' when importing into Azure KeyVault",
+              "DisplayName": "Non Exportable Private Key",
+              "Description": "If true, this will mark the certificate as having a non-exportable private key when importing into Azure KeyVault",
               "Type": "Bool",
               "DefaultValue": "False",
               "RequiredWhen": {

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -46,7 +46,20 @@
                 "OnRemove": false,
                 "OnReenrollment": false
               }
-            }            
+            },
+            {
+              "Name": "NonExportable",
+              "DisplayName": "Non Exportable",
+              "Description": "If true, this will mark the certificate as 'non-exportable' when importing into Azure KeyVault",
+              "Type": "Bool",
+              "DefaultValue": "False",
+              "RequiredWhen": {
+                "HasPrivateKey": false,
+                "OnAdd": false,
+                "OnRemove": false,
+                "OnReenrollment": false
+              }
+            }  
           ],
           "JobProperties": [],
           "LocalStore": false,


### PR DESCRIPTION
* added an optional entry parameter to indicate whether the private key of the cert should be not exportable when stored in KeyVault
* now specifying the pkcs12 format when wirting certs to Azure KeyVault.  This should prevent the error when a PEM cert was added outside of Command and then we attempt to update without specifying the format (Azure assumes PEM and throws an error if not).